### PR TITLE
ci(update-workflow): Switch to actions/attest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
             --data-binary @${_filename} \
             https://uploads.github.com/repos/${{ github.repository_owner }}/tx-submit-api-mirror/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}
       - name: Attest binary
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
           subject-path: 'tx-submit-api-mirror'
 
@@ -136,13 +136,13 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Attest Docker Hub image
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
           subject-name: index.docker.io/blinklabs/tx-submit-api-mirror
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
       - name: Attest GHCR image
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the publish workflow to `actions/attest` v4.1.0 for build provenance, replacing `actions/attest-build-provenance` and pinning the action for security. Attestations continue for the binary and both Docker images (Docker Hub and GHCR) with no behavior changes.

<sup>Written for commit 03d70efeaf1e417ba442da475570a01202ac7e25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build automation workflow to use the latest version of the attestation action for improved artifact verification and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->