### PR TITLE
chore: Use SHA for GitHub workflows

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -16,18 +16,18 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
         with:
           fetch-depth: '0'
       - name: qemu
-        uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4 https://github.com/docker/setup-qemu-action/releases/tag/v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4 https://github.com/docker/setup-buildx-action/releases/tag/v4
       - id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6 https://github.com/docker/metadata-action/releases/tag/v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7 https://github.com/docker/build-push-action/releases/tag/v7
         with:
           context: .
           push: false

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -13,5 +13,5 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6.0.3
-      - uses: webiny/action-conventional-commits@v1.4.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
+      - uses: webiny/action-conventional-commits@7f91b1595ca1951cdb671ddc9f07a49081ec5b69 # v1.4.2 https://github.com/webiny/action-conventional-commits/releases/tag/v1.4.2

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v5.0.1 https://github.com/actions/checkout/releases/tag/v5.0.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0 https://github.com/actions/setup-go/releases/tag/v6.0.0
         with:
           go-version: 1.25.x

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -15,7 +15,7 @@ jobs:
     name: nilaway
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v5.0.1 https://github.com/actions/checkout/releases/tag/v5.0.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0 https://github.com/actions/setup-go/releases/tag/v6.0.0
         with:
           go-version: 1.25.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       RELEASE_ID: ${{ steps.create-release.outputs.result }}
     steps:
       - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9 https://github.com/actions/github-script/releases/tag/v9
         id: create-release
         if: startsWith(github.ref, 'refs/tags/')
         with:
@@ -57,10 +57,10 @@ jobs:
       statuses: write
     steps:
       - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
         with:
           fetch-depth: '0'
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6 https://github.com/actions/setup-go/releases/tag/v6
         with:
           go-version: 1.25.x
       - name: Build binary
@@ -96,26 +96,26 @@ jobs:
       statuses: write
     steps:
       - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
         with:
           fetch-depth: '0'
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4 https://github.com/docker/setup-qemu-action/releases/tag/v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4 https://github.com/docker/setup-buildx-action/releases/tag/v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4 https://github.com/docker/login-action/releases/tag/v4
         with:
           username: blinklabs
           password: ${{ secrets.DOCKER_PASSWORD }} # uses token
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4 https://github.com/docker/login-action/releases/tag/v4
         with:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
       - id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6 https://github.com/docker/metadata-action/releases/tag/v6
         with:
           images: |
             blinklabs/tx-submit-api-mirror
@@ -128,7 +128,7 @@ jobs:
             # semver
             type=semver,pattern={{version}}
       - name: Build images
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7 https://github.com/docker/build-push-action/releases/tag/v7
         id: push
         with:
           outputs: "type=registry,push=true"
@@ -149,7 +149,7 @@ jobs:
           push-to-registry: true
       # Update Docker Hub from README
       - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5 https://github.com/peter-evans/dockerhub-description/releases/tag/v5
         with:
           username: blinklabs
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -163,7 +163,7 @@ jobs:
       contents: write
     needs: [create-draft-release, build-binaries, build-images]
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9 https://github.com/actions/github-script/releases/tag/v9
         if: startsWith(github.ref, 'refs/tags/')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
1. Fetched each version tag by checking in the UI of that particular tag also validated each tag version SHA with this command as well (git ls-remote https://github.com/OWNER/REPO.git 'refs/tags/TAG^{}').
2. Updated all the workflows with SHA and modified the version tag value for conventional-commit & golangci-lint workflows.

Example
```
akrepala@akrepalas-MacBook-Pro nview % git ls-remote https://github.com/actions/checkout.git 'refs/tags/v6.0.3^{}'
df4cb1c069e1874edd31b4311f1884172cec0e10        refs/tags/v6.0.3^{}
akrepala@akrepalas-MacBook-Pro nview % 
```

Closes #334 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin all GitHub Actions in our workflows to immutable commit SHAs to improve supply‑chain security and reproducibility. Closes #334.

- **Dependencies**
  - Pinned actions across `ci-docker`, `publish`, `conventional-commits`, `golangci-lint`, and `nilaway` (e.g., `actions/checkout` v6.0.3, `actions/setup-go` v6, `docker/*` v4/v6/v7, `actions/github-script` v9, `webiny/action-conventional-commits` v1.4.2, `peter-evans/dockerhub-description` v5).
  - Added release-tag comments and links beside each SHA for traceability.

<sup>Written for commit 1e662440fbcbf3364cdfe45bf9c09fc9d52435c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/tx-submit-api-mirror/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

